### PR TITLE
Allow manual disconnect/reconnect

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -47,7 +47,7 @@ function Socket(options) {
         return createBrowserChannel();
       }
 
-      if (options.reconnect && event.code !== 1000) {
+      if (options.reconnect && !event.wasClean) {
         setTimeout(function () {
           createWebSocket();
         }, (options.timeout || 10000) + (options.timeoutIncrement || 10000) * self.attemptNum);


### PR DESCRIPTION
racer-highway breaks racer's `model.disconnect()` by automatically reconnecting, and `model.connect()` by not exposing the required `socket.open()` function.
