### PR TITLE
Added client options to specify server websocket listening port

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -19,7 +19,6 @@ function Socket(options) {
     port = ":" + CLIENT_OPTIONS.srvSecurePort;
   }
   self.url = protocol + '//' + window.location.host + (port || "") + CLIENT_OPTIONS.base;
-  console.log("self.url", self.url);
 
   function createWebSocket () {
     self.type = 'websocket';


### PR DESCRIPTION
Deploying my apps to OpenShift, I need the websocket client connecting to either 8000 (ws) or 8443 (wss), which was not retrieved correctly by `window.location.host`.

I've added `clientOptions.srvPort` and `clientOptions.srvSecurePort` options - ws and wss respectively -  so that we may specify at which port the client may connect to the server through websockets.
