### PR TITLE
Factor out the browserify transform so that it can be used in a gulp task

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,25 @@ var serverOptions = {
 var handlers = racerHighWay(store, serverOptions);
 ```
 
+## Browserify
+
+Racer Highway will bundle the client browser script using Browserify in the
+call to `store.bundle(...)`, as illustrated in the
+[racer-examples](https://github.com/derbyjs/racer-examples).  However, if you
+want to do this ahead of time, you can add this to your gulp browserify task
+using something like:
+
+```
+var browserify = require('browserify');
+var racerClientBundle = require('racer-highway/lib/bundle');
+
+// ...
+
+bundler = browserify(opts);
+// this adds the racer-highway/lib/browser.js to our bundle
+(racerClientBundle())(bundler);
+```
+
 ## WebSocket Info
 
 * [What is WebSocket?](https://www.websocket.org/)

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -1,0 +1,44 @@
+var path = require('path');
+var through = require('through');
+var extend = require('extend');
+
+var defaultClientOptions = {
+  base: '/channel',
+  reconnect: true,
+  browserChannelOnly: false,
+  srvProtocol: undefined,
+  srvHost: undefined,
+  srvPort: undefined,
+  srvSecurePort: undefined,
+  timeout: 10000,
+  timeoutIncrement: 10000
+};
+
+module.exports = function(clientOptions) {
+  clientOptions = clientOptions || {};
+  clientOptions = extend({}, defaultClientOptions, clientOptions);
+
+  var clientOptionsJson = JSON.stringify(clientOptions);
+
+  // Add the client side script to the Browserify bundle. Set the clientOptions
+  // needed to connect to the corresponding server by injecting them into the
+  // file during bundling
+  return function(bundle) {
+    var browserFilename = path.join(__dirname, 'browser.js');
+    bundle.transform(function(filename) {
+      if (filename !== browserFilename) return through();
+      var file = '';
+      return through(
+        function write(data) {
+          file += data;
+        }
+        , function end() {
+          var rendered = file.replace('{{clientOptions}}', clientOptionsJson);
+          this.queue(rendered);
+          this.queue(null);
+        }
+      );
+    });
+    bundle.add(browserFilename);
+  };
+}

--- a/lib/server.js
+++ b/lib/server.js
@@ -2,23 +2,10 @@ var Duplex = require('stream').Duplex;
 var WebSocket = require('ws');
 var WebSocketServer = WebSocket.Server;
 var BrowserChannelServer = require('browserchannel').server;
-var through = require('through');
-var path = require('path');
 var crypto = require('crypto');
-
 var extend = require('extend');
 
-var defaultClientOptions = {
-  base: '/channel',
-  reconnect: true,
-  browserChannelOnly: false,
-  srvProtocol: undefined,
-  srvHost: undefined,
-  srvPort: undefined,
-  srvSecurePort: undefined,
-  timeout: 10000,
-  timeoutIncrement: 10000
-};
+var bundle = require('./bundle');
 
 var defaultServerOptions = {
   session: null,
@@ -30,41 +17,14 @@ var defaultServerOptions = {
 module.exports = function(store, serverOptions, clientOptions) {
 
   serverOptions = serverOptions || {};
-  clientOptions = clientOptions || {};
-
-  clientOptions = extend({}, defaultClientOptions, clientOptions);
   serverOptions = extend({}, defaultServerOptions, serverOptions);
 
   // ws-module specific options
   serverOptions.path = serverOptions.base;
   serverOptions.noServer = true;
 
-  var clientOptionsJson = JSON.stringify(clientOptions);
-
-  serverOptions.noServer = true;
-
-  // Add the client side script to the Browserify bundle. Set the clientOptions
-  // needed to connect to the corresponding server by injecting them into the
-  // file during bundling
-  store.on('bundle', function(bundle) {
-    var browserFilename = path.join(__dirname, 'browser.js');
-    bundle.transform(function(filename) {
-      if (filename !== browserFilename) return through();
-      var file = '';
-      return through(
-        function write(data) {
-          file += data;
-        }
-        , function end() {
-          var rendered = file.replace('{{clientOptions}}', clientOptionsJson);
-          this.queue(rendered);
-          this.queue(null);
-        }
-      );
-    });
-    bundle.add(browserFilename);
-  });
-
+  // add the client side script to the Browserify bundle
+  store.on('bundle', bundle(clientOptions));
 
   var middleware = BrowserChannelServer(serverOptions, function(client, connectRequest) {
 


### PR DESCRIPTION
racer-browserchannel and racer-highway are made to be used with browserify at runtime, however other architectures are possible (desirable?) such as pre-creating a script in a gulp or grunt task.

This change enables the code to be reused in that way -- see the change to the README.md for how.

Client options can be overridden in the call to racerClientBundle(clientOptions) if necessary.