### PR TITLE
Add API to allow client browser to override connection options / add extraParams

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,22 @@ In addition, there is a `racer.overrideClientOptions(overrideOptions)` method
 that can be called on the client before `racer.createModel(data)` to provide
 extra, dynamic, customisation post-bundling.
 
+This can be used in the client browser code to, for example, force the use of
+browser channel (for testing) or pass an extraParams object:
+
+```js
+racer.overrideClientOptions({
+  browserChannelOnly: true,
+  extraParams: {
+    ticket: "<authentication-ticket>"
+  }
+})
+```
+
+`extraParams` holds name-value pairs that will get added to the query string
+of the websocket connection request and each browser channel request and can
+be useful for implementing ticket based (non-cookie) session authentication.
+
 ## WebSocket Info
 
 * [What is WebSocket?](https://www.websocket.org/)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ call to `store.bundle(...)`, as illustrated in the
 want to do this ahead of time, you can add this to your gulp browserify task
 using something like:
 
-```
+```js
 var browserify = require('browserify');
 var racerClientBundle = require('racer-highway/lib/bundle');
 
@@ -68,6 +68,15 @@ bundler = browserify(opts);
 // this adds the racer-highway/lib/browser.js to our bundle
 (racerClientBundle())(bundler);
 ```
+
+## Client Options
+
+A client options object can be passed to `racerClientBundle(clientOptions)`
+to override some aspects of the default behaviour.
+
+In addition, there is a `racer.overrideClientOptions(overrideOptions)` method
+that can be called on the client before `racer.createModel(data)` to provide
+extra, dynamic, customisation post-bundling.
 
 ## WebSocket Info
 

--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -1,8 +1,15 @@
 var racer = require('racer');
+var extend = require('extend');
 var Socket = require('./socket');
 var CLIENT_OPTIONS = JSON.parse('{{clientOptions}}');
 
+var overrideOptions = {};
+
+racer.overrideClientOptions = function(options) {
+  overrideOptions = options;
+};
+
 racer.Model.prototype._createSocket = function(bundle) {
-  return new Socket(CLIENT_OPTIONS);
+  return new Socket(extend({}, CLIENT_OPTIONS, overrideOptions));
 };
 

--- a/lib/browser/socket.js
+++ b/lib/browser/socket.js
@@ -181,7 +181,22 @@ function getWebSocketURL(options){
   } else if (protocol === 'wss:' && srvSecurePort) {
     port = ":" + srvSecurePort;
   }
-  return protocol + '//' + srvHost + (port || "") + options.base;
+
+  var extraParams = '';
+  if (options.extraParams) {
+    var params = options.extraParams;
+    var query = [];
+    for (var p in params) {
+      if (params.hasOwnProperty(p)) {
+        query.push(encodeURIComponent(p) + "=" + encodeURIComponent(params[p]));
+      }
+    }
+    if (query.length > 0) {
+      extraParams = '?' + query.join("&");
+    }
+  }
+
+  return protocol + '//' + srvHost + (port || "") + options.base + extraParams;
 }
 
 // Maybe need to use reconnection timing algorithm from


### PR DESCRIPTION
Currently racer-highway clientOptions are set at bundling time and there's no way for the client web browser code to change these.

This PR adds a `overrideClientOptions()` method to racer that provides a way for these to be modified or added to on a per-browser basis.  This could be used, for example, to set the `browserChannelOnly` setting for testing purposes.

In particular, this also allows you to specify [`extraParams`](https://github.com/josephg/node-browserchannel/blob/2be5bdb9d15d185ffb2cb2d92fb0161f93d1fd6a/lib/bcsocket.coffee#L33-L36) on a per-connection basis, which can be useful for implementing a ticket-based authentication system.

The PR adds corresponding support for `extraParams` for a normal websocket connection.  These values get appended to a query string that is added to the URL when making the initial connection.