### PR TITLE
fix(_write): prevent uncaught errors, e.g. write EPIPE.

### DIFF
--- a/lib/server/createWebSocketStream.js
+++ b/lib/server/createWebSocketStream.js
@@ -56,8 +56,8 @@ class ClientStream extends Duplex {
     if (this.client.readyState !== WebSocket.OPEN) return callback()
     this.client.send(JSON.stringify(chunk), function (err) {
       if (err) console.error('[racer-highway] send:', err)
+      callback()
     })
-    callback()
   }
 
   _stopClient () {


### PR DESCRIPTION
Handling errors
```
uncaught: Error: write EPIPE
    at afterWriteDispatched (node:internal/stream_base_commons:160:15)
    at writeGeneric (node:internal/stream_base_commons:151:3)
    at Socket._writeGeneric (node:net:962:11)
    at Socket._write (node:net:974:8)
    at writeOrBuffer (node:internal/streams/writable:392:12)
    at _write (node:internal/streams/writable:333:10)
    at Socket.Writable.write (node:internal/streams/writable:337:10)
    at Sender.sendFrame (/app/node_modules/racer-highway/node_modules/ws/lib/Sender.js:381:20)
    at Sender.doClose (/app/node_modules/racer-highway/node_modules/ws/lib/Sender.js:142:10)
    at Sender.close (/app/node_modules/racer-highway/node_modules/ws/lib/Sender.js:129:12)
    at WebSocket.close (/app/node_modules/racer-highway/node_modules/ws/lib/WebSocket.js:285:18)
    at Receiver._receiver.onclose (/app/node_modules/racer-highway/node_modules/ws/lib/WebSocket.js:155:12)
    at Receiver.controlMessage (/app/node_modules/racer-highway/node_modules/ws/lib/Receiver.js:425:14)
    at Receiver.getData (/app/node_modules/racer-highway/node_modules/ws/lib/Receiver.js:325:12)
    at Receiver.startLoop (/app/node_modules/racer-highway/node_modules/ws/lib/Receiver.js:165:16)
    at Receiver.add (/app/node_modules/racer-highway/node_modules/ws/lib/Receiver.js:139:10)
```